### PR TITLE
Changes the drop down content menu - Take 2

### DIFF
--- a/docs/getting-started-with-mentoring/_category_.json
+++ b/docs/getting-started-with-mentoring/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "The Mentoring Mindset",
+  "label": "Getting Started with Mentoring",
   "position": 3
 }

--- a/docs/meeting-with-your-mentoring-partner/_category_.json
+++ b/docs/meeting-with-your-mentoring-partner/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Meeting with your Mentoring Partner",
+  "position": 3
+}

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -1,7 +1,7 @@
 ---
-sidebar_position: 1
-title: Introduction
-id: intro
+sidebar_position: 2
+title: Welcome
+id: welcome
 ---
 
 # The Ultimate Developer Mentoring Guide


### PR DESCRIPTION
Changes the drop down content on docusaurus. Should become:
- Introduction
> Welcome
> About Project Thrive
> About OfferZen
> How to use this handbook