### PR TITLE
Update to include Radical Candour table instead of image.

### DIFF
--- a/docs/essential-mentoring-resources/giving-and-receiving-feedback/README.md
+++ b/docs/essential-mentoring-resources/giving-and-receiving-feedback/README.md
@@ -74,7 +74,12 @@ But first, what’s Radical Candour? The term, coined by Kim Scott in her book  
 
 The framework guides us to provide feedback from a place of caring, and to do this by challenging directly, i.e. we care enough to have the tough conversations, instead of sugar-coating the truth.
 
-![](<//img/assets/radical-candor-table.png>)
+
+|  | **Silence** | **Challenge Directly** |
+|---|---|---|
+| **Uncaring** | *Manipulative Insincerity* - Individuals approaching feedback from this dynamic neither care for the person they are engaging with nor challenge them with feedback that will help them to grow. Instead, they may be polite on the surface, but critical behind closed doors. | *Obnoxious Aggression* - The individual does challenge directly, but they do this without care for the individual receiving the feedback. This equates to brutal honesty and feedback that may be unkind. |
+| **Care Personally** | *Ruinous Empathy* - When we approach a situation with caring, but don't speak up, we fall into ruinous empathy. In this dynamic, we put our concern for someone's feelings above their long-term potential for growth. We may default to praise and provide unspecific or sugar-coated feedback. | *Radical Candour* - The individual provides feedback that is kind and clear, and praise is sincere and specific. |
+
 
 ### Responding to Feedback
 


### PR DESCRIPTION
I've chosen to italicize the name of each category instead of adding breaks between the categories and descriptions because I wasn't able to quickly find a way to vertically align the markdown table text. If I find a way I'll come back and edit it. This solution temporarily neatens it.

e.g. uneven spacing
![image](https://user-images.githubusercontent.com/41687866/186416725-825d0620-9713-48e6-818a-01ed83d5894e.png)

vs.

more consistent spacing
![image](https://user-images.githubusercontent.com/41687866/186416866-ce9710ef-9618-4140-b8e7-877086ba5148.png)
