### PR TITLE
feat: add sitemap config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -61,6 +61,12 @@ const config = {
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
         },
+        sitemap: {
+          changefreq: 'weekly',
+          priority: 0.5,
+          ignorePatterns: ['/tags/**'],
+          filename: 'sitemap.xml',
+        },
       }),
     ],
   ],


### PR DESCRIPTION

@docusaurus/plugin-sitemap already gets installed as part of @docusaurus/preset-classic. It just needs to be configured

```
changefreq: 'weekly',            // How frequently the page is likely to change
priority: 0.5,                            // The priority of this URL relative to other URLs on your site. Default priority of a page is 0.5.
ignorePatterns: ['/tags/**'], 
filename: 'sitemap.xml',

```