### PR TITLE
fix letter-casing in partial .mdx files

### DIFF
--- a/src/components/MentoringScenarios/Scenario.js
+++ b/src/components/MentoringScenarios/Scenario.js
@@ -9,14 +9,8 @@ const Scenario = (props) => {
 
   return (
     <>
-      {/* <_Scenario1 /> */}
       {props.scenario}
-      <button
-        // className="btn btn-primary inline-flex items-center ml-1 rounded-md border hover:no-underline"
-        // style={{ marginBottom: "var(--ifm-leading)" }}
-        className={style.btn}
-        onClick={handleRevealMissingIngredient}
-      >
+      <button className={style.btn} onClick={handleRevealMissingIngredient}>
         {revealMissingIngredient
           ? "Hide Missing Ingredient..."
           : "Reveal Missing Ingredient..."}

--- a/src/components/MentoringScenarios/Scenarios.js
+++ b/src/components/MentoringScenarios/Scenarios.js
@@ -1,12 +1,12 @@
 import React from "react";
 import Scenario from "./Scenario";
-import _Scenario1 from "./partials/_Scenario1.mdx";
+import _Scenario1 from "./partials/_scenario1.mdx";
 import __Scenario1_missingIngredient from "./partials/_scenario1_missingIngredient.mdx";
-import _Scenario2 from "./partials/_Scenario2.mdx";
+import _Scenario2 from "./partials/_scenario2.mdx";
 import __Scenario2_missingIngredient from "./partials/_scenario2_missingIngredient.mdx";
-import _Scenario3 from "./partials/_Scenario3.mdx";
+import _Scenario3 from "./partials/_scenario3.mdx";
 import __Scenario3_missingIngredient from "./partials/_scenario3_missingIngredient.mdx";
-import _Scenario4 from "./partials/_Scenario4.mdx";
+import _Scenario4 from "./partials/_scenario4.mdx";
 import __Scenario4_missingIngredient from "./partials/_scenario4_missingIngredient.mdx";
 
 const Scenarios = () => {


### PR DESCRIPTION
Need feature to help toggle between hiding and showing an element in page https://github.com/OfferZen-Community/developer-mentoring/issues/157

Fix deployment error caused by syntax error in import statements (letter-casing inconsistencies).
1. In Scenarios.js fixed partial .mdx files name (for eg. from:  
```
import _Scenario1 from "./partials/_Scenario1.mdx";
```

to:

```
import _Scenario1 from "./partials/_scenario1.mdx";
```
